### PR TITLE
Uses the complete base path for LarkBot

### DIFF
--- a/src/Client/LarkBotClient.php
+++ b/src/Client/LarkBotClient.php
@@ -32,7 +32,7 @@ class LarkBotClient
                     config("larkbot.bots.{$botName}.app_id"),
                     config("larkbot.bots.{$botName}.app_secret"),
                     config("larkbot.bots.{$botName}.allowed_domain_names"),
-                    Str::beforeLast(config("larkbot.base_path"), '/'),
+                    config("larkbot.base_path"),
                 )
             ];
         });


### PR DESCRIPTION
Updates the LarkBot client to use the complete base path configuration, ensuring correct API endpoint construction. Previously, the last segment of the base path was being incorrectly removed.